### PR TITLE
Chain append/prepend

### DIFF
--- a/lib/lotus/utils/callbacks.rb
+++ b/lib/lotus/utils/callbacks.rb
@@ -58,7 +58,7 @@ module Lotus
           @chain.uniq!
         end
 
-        # Preprends the given callbacks to the beginning of the chain.
+        # Prepends the given callbacks to the beginning of the chain.
         #
         # @param callbacks [Array] one or multiple callbacks to add
         # @param block [Proc] an optional block to be added

--- a/lib/lotus/utils/callbacks.rb
+++ b/lib/lotus/utils/callbacks.rb
@@ -51,12 +51,15 @@ module Lotus
         #   # If the #notificate method accepts some argument(s) they should be passed when `run` is invoked.
         #   chain.append :notificate
         def append(*callbacks, &block)
-          process(callbacks, block) do |callables|
-            @chain.push(*callables)
+          callbacks.push block if block_given?
+          callbacks.each do |c|
+            @chain.push Factory.fabricate(c)
           end
+
+          @chain.uniq!
         end
 
-        # Prepends the given callbacks to the beginning of the chain.
+        # Preprends the given callbacks to the beginning of the chain.
         #
         # @param callbacks [Array] one or multiple callbacks to add
         # @param block [Proc] an optional block to be added
@@ -88,9 +91,12 @@ module Lotus
         #   # If the #notificate method accepts some argument(s) they should be passed when `run` is invoked.
         #   chain.prepend :notificate
         def prepend(*callbacks, &block)
-          process(callbacks, block) do |callables|
-            @chain.unshift(*callables)
+          callbacks.push block if block_given?
+          callbacks.each do |c|
+            @chain.unshift Factory.fabricate(c)
           end
+
+          @chain.uniq!
         end
 
         # Runs all the callbacks in the chain.
@@ -163,16 +169,6 @@ module Lotus
           super
           @chain.freeze
         end
-
-
-        private
-
-        def process(callbacks, block = nil)
-          callbacks.push(block) if block
-          yield callbacks.map { |c| Factory.fabricate(c) }
-          @chain.uniq!
-        end
-
       end
 
       # Callback factory

--- a/lib/lotus/utils/callbacks.rb
+++ b/lib/lotus/utils/callbacks.rb
@@ -22,12 +22,13 @@ module Lotus
         # Appends the given callbacks to the end of the chain.
         #
         # @param callbacks [Array] one or multiple callbacks to add
-        # @param blk [Proc] an optional block to be added
+        # @param block [Proc] an optional block to be added
         #
         # @return [void]
         #
         # @raise [RuntimeError] if the object was previously frozen
         #
+        # @see #prepend
         # @see #run
         # @see Lotus::Utils::Callbacks::Callback
         # @see Lotus::Utils::Callbacks::MethodCallback
@@ -43,16 +44,56 @@ module Lotus
         #   # Add a Proc to be used as a callback, it will be wrapped by `Callback`
         #   # The optional argument(s) correspond to the one passed when invoked the chain with `run`.
         #   chain.append { Authenticator.authenticate! }
-        #   chain.append {|params| ArticleRepository.find(params[:id]) }
+        #   chain.append { |params| ArticleRepository.find(params[:id]) }
         #
         #   # Add a Symbol as a reference to a method name that will be used as a callback.
         #   # It will wrapped by `MethodCallback`
         #   # If the #notificate method accepts some argument(s) they should be passed when `run` is invoked.
         #   chain.append :notificate
-        def append(*callbacks, &blk)
-          callbacks.push blk if block_given?
+        def append(*callbacks, &block)
+          callbacks.push block if block_given?
           callbacks.each do |c|
             @chain.push Factory.fabricate(c)
+          end
+
+          @chain.uniq!
+        end
+
+        # Preprends the given callbacks to the beginning of the chain.
+        #
+        # @param callbacks [Array] one or multiple callbacks to add
+        # @param block [Proc] an optional block to be added
+        #
+        # @return [void]
+        #
+        # @raise [RuntimeError] if the object was previously frozen
+        #
+        # @see #append
+        # @see #run
+        # @see Lotus::Utils::Callbacks::Callback
+        # @see Lotus::Utils::Callbacks::MethodCallback
+        # @see Lotus::Utils::Callbacks::Chain#freeze
+        #
+        # @since x.x.x
+        #
+        # @example
+        #   require 'lotus/utils/callbacks'
+        #
+        #   chain = Lotus::Utils::Callbacks::Chain.new
+        #
+        #   # Add a Proc to be used as a callback, it will be wrapped by `Callback`
+        #   # The optional argument(s) correspond to the one passed when invoked the chain with `run`.
+        #   chain.prepend { Authenticator.authenticate! }
+        #   chain.prepend { |params| ArticleRepository.find(params[:id]) }
+        #
+        #   # Add a Symbol as a reference to a method name that will be used as a callback.
+        #   # It will wrapped by `MethodCallback`
+        #   # If the #notificate method accepts some argument(s) they should be passed when `run` is invoked.
+        #   chain.prepend :notificate
+        def prepend(*callbacks, &block)
+          callbacks.push block if block_given?
+          callbacks.each do |c|
+            @chain.unshift Factory.fabricate(c)
           end
 
           @chain.uniq!

--- a/lib/lotus/utils/callbacks.rb
+++ b/lib/lotus/utils/callbacks.rb
@@ -51,9 +51,8 @@ module Lotus
         #   # If the #notificate method accepts some argument(s) they should be passed when `run` is invoked.
         #   chain.append :notificate
         def append(*callbacks, &block)
-          callbacks.push block if block_given?
-          callbacks.each do |c|
-            @chain.push Factory.fabricate(c)
+          callables(callbacks, block).each do |c|
+            @chain.push(c)
           end
 
           @chain.uniq!
@@ -91,9 +90,8 @@ module Lotus
         #   # If the #notificate method accepts some argument(s) they should be passed when `run` is invoked.
         #   chain.prepend :notificate
         def prepend(*callbacks, &block)
-          callbacks.push block if block_given?
-          callbacks.each do |c|
-            @chain.unshift Factory.fabricate(c)
+          callables(callbacks, block).each do |c|
+            @chain.unshift(c)
           end
 
           @chain.uniq!
@@ -169,6 +167,15 @@ module Lotus
           super
           @chain.freeze
         end
+
+
+        private
+
+        def callables(callbacks, block)
+          callbacks.push(block) if block
+          callbacks.map { |c| Factory.fabricate(c) }
+        end
+
       end
 
       # Callback factory

--- a/lib/lotus/utils/callbacks.rb
+++ b/lib/lotus/utils/callbacks.rb
@@ -51,15 +51,12 @@ module Lotus
         #   # If the #notificate method accepts some argument(s) they should be passed when `run` is invoked.
         #   chain.append :notificate
         def append(*callbacks, &block)
-          callbacks.push block if block_given?
-          callbacks.each do |c|
-            @chain.push Factory.fabricate(c)
+          process(callbacks, block) do |callables|
+            @chain.push(*callables)
           end
-
-          @chain.uniq!
         end
 
-        # Preprends the given callbacks to the beginning of the chain.
+        # Prepends the given callbacks to the beginning of the chain.
         #
         # @param callbacks [Array] one or multiple callbacks to add
         # @param block [Proc] an optional block to be added
@@ -91,12 +88,9 @@ module Lotus
         #   # If the #notificate method accepts some argument(s) they should be passed when `run` is invoked.
         #   chain.prepend :notificate
         def prepend(*callbacks, &block)
-          callbacks.push block if block_given?
-          callbacks.each do |c|
-            @chain.unshift Factory.fabricate(c)
+          process(callbacks, block) do |callables|
+            @chain.unshift(*callables)
           end
-
-          @chain.uniq!
         end
 
         # Runs all the callbacks in the chain.
@@ -169,6 +163,16 @@ module Lotus
           super
           @chain.freeze
         end
+
+
+        private
+
+        def process(callbacks, block = nil)
+          callbacks.push(block) if block
+          yield callbacks.map { |c| Factory.fabricate(c) }
+          @chain.uniq!
+        end
+
       end
 
       # Callback factory

--- a/lib/lotus/utils/callbacks.rb
+++ b/lib/lotus/utils/callbacks.rb
@@ -19,7 +19,7 @@ module Lotus
           @chain = Array.new
         end
 
-        # Adds the given callbacks to the chain
+        # Appends the given callbacks to the end of the chain.
         #
         # @param callbacks [Array] one or multiple callbacks to add
         # @param blk [Proc] an optional block to be added
@@ -42,14 +42,14 @@ module Lotus
         #
         #   # Add a Proc to be used as a callback, it will be wrapped by `Callback`
         #   # The optional argument(s) correspond to the one passed when invoked the chain with `run`.
-        #   chain.add { Authenticator.authenticate! }
-        #   chain.add {|params| ArticleRepository.find(params[:id]) }
+        #   chain.append { Authenticator.authenticate! }
+        #   chain.append {|params| ArticleRepository.find(params[:id]) }
         #
         #   # Add a Symbol as a reference to a method name that will be used as a callback.
         #   # It will wrapped by `MethodCallback`
         #   # If the #notificate method accepts some argument(s) they should be passed when `run` is invoked.
-        #   chain.add :notificate
-        def add(*callbacks, &blk)
+        #   chain.append :notificate
+        def append(*callbacks, &blk)
           callbacks.push blk if block_given?
           callbacks.each do |c|
             @chain.push Factory.fabricate(c)

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -10,6 +10,10 @@ Lotus::Utils::Callbacks::Chain.class_eval do
     @chain.first
   end
 
+  def last
+    @chain.last
+  end
+
   def each(&blk)
     @chain.each(&blk)
   end
@@ -46,8 +50,16 @@ describe Lotus::Utils::Callbacks::Chain do
     it 'wraps the given callback with a callable object' do
       @chain.append :symbolize!
 
-      cb = @chain.first
+      cb = @chain.last
       cb.must_respond_to(:call)
+    end
+
+    it 'appends the callbacks at the end of the chain' do
+      @chain.append(:foo)
+
+      @chain.append(:bar)
+      @chain.first.callback.must_equal(:foo)
+      @chain.last.callback.must_equal(:bar)
     end
 
     describe 'when a callable object is passed' do
@@ -58,7 +70,7 @@ describe Lotus::Utils::Callbacks::Chain do
       let(:callback) { Callable.new }
 
       it 'includes the given callback' do
-        cb = @chain.first
+        cb = @chain.last
         cb.callback.must_equal(callback)
       end
     end
@@ -71,7 +83,7 @@ describe Lotus::Utils::Callbacks::Chain do
       let(:callback) { :upcase }
 
       it 'includes the given callback' do
-        cb = @chain.first
+        cb = @chain.last
         cb.callback.must_equal(callback)
       end
 
@@ -90,7 +102,7 @@ describe Lotus::Utils::Callbacks::Chain do
       let(:callback) { Proc.new{} }
 
       it 'includes the given callback' do
-        cb = @chain.first
+        cb = @chain.last
         assert_equal cb.callback, callback
       end
     end
@@ -98,6 +110,86 @@ describe Lotus::Utils::Callbacks::Chain do
     describe 'when multiple callbacks are passed' do
       before do
         @chain.append(*callbacks)
+      end
+
+      let(:callbacks) { [:upcase, Callable.new, Proc.new{}] }
+
+      it 'includes all the given callbacks' do
+        @chain.size.must_equal(callbacks.size)
+      end
+
+      it 'all the included callbacks are callable' do
+        @chain.each do |callback|
+          callback.must_respond_to(:call)
+        end
+      end
+    end
+  end
+
+  describe '#prepend' do
+    it 'wraps the given callback with a callable object' do
+      @chain.prepend :symbolize!
+
+      cb = @chain.first
+      cb.must_respond_to(:call)
+    end
+
+    it 'prepends the callbacks at the beginning of the chain' do
+      @chain.append(:foo)
+
+      @chain.prepend(:bar)
+      @chain.first.callback.must_equal(:bar)
+      @chain.last.callback.must_equal(:foo)
+    end
+
+    describe 'when a callable object is passed' do
+      before do
+        @chain.prepend callback
+      end
+
+      let(:callback) { Callable.new }
+
+      it 'includes the given callback' do
+        cb = @chain.first
+        cb.callback.must_equal(callback)
+      end
+    end
+
+    describe 'when a Symbol is passed' do
+      before do
+        @chain.prepend callback
+      end
+
+      let(:callback) { :upcase }
+
+      it 'includes the given callback' do
+        cb = @chain.first
+        cb.callback.must_equal(callback)
+      end
+
+      it 'guarantees unique entries' do
+        # append the callback again, see before block
+        @chain.prepend callback
+        @chain.size.must_equal(1)
+      end
+    end
+
+    describe 'when a block is passed' do
+      before do
+        @chain.prepend(&callback)
+      end
+
+      let(:callback) { Proc.new{} }
+
+      it 'includes the given callback' do
+        cb = @chain.first
+        assert_equal cb.callback, callback
+      end
+    end
+
+    describe 'when multiple callbacks are passed' do
+      before do
+        @chain.prepend(*callbacks)
       end
 
       let(:callbacks) { [:upcase, Callable.new, Proc.new{}] }

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -42,9 +42,9 @@ describe Lotus::Utils::Callbacks::Chain do
     @chain = Lotus::Utils::Callbacks::Chain.new
   end
 
-  describe '#add' do
+  describe '#append' do
     it 'wraps the given callback with a callable object' do
-      @chain.add :symbolize!
+      @chain.append :symbolize!
 
       cb = @chain.first
       cb.must_respond_to(:call)
@@ -52,7 +52,7 @@ describe Lotus::Utils::Callbacks::Chain do
 
     describe 'when a callable object is passed' do
       before do
-        @chain.add callback
+        @chain.append callback
       end
 
       let(:callback) { Callable.new }
@@ -65,7 +65,7 @@ describe Lotus::Utils::Callbacks::Chain do
 
     describe 'when a Symbol is passed' do
       before do
-        @chain.add callback
+        @chain.append callback
       end
 
       let(:callback) { :upcase }
@@ -76,15 +76,15 @@ describe Lotus::Utils::Callbacks::Chain do
       end
 
       it 'guarantees unique entries' do
-        # add the callback again, see before block
-        @chain.add callback
+        # append the callback again, see before block
+        @chain.append callback
         @chain.size.must_equal(1)
       end
     end
 
     describe 'when a block is passed' do
       before do
-        @chain.add(&callback)
+        @chain.append(&callback)
       end
 
       let(:callback) { Proc.new{} }
@@ -97,7 +97,7 @@ describe Lotus::Utils::Callbacks::Chain do
 
     describe 'when multiple callbacks are passed' do
       before do
-        @chain.add(*callbacks)
+        @chain.append(*callbacks)
       end
 
       let(:callbacks) { [:upcase, Callable.new, Proc.new{}] }
@@ -120,7 +120,7 @@ describe Lotus::Utils::Callbacks::Chain do
 
     describe 'when symbols are passed' do
       before do
-        @chain.add :authenticate!, :set_article
+        @chain.append :authenticate!, :set_article
         @chain.run action, params
       end
 
@@ -135,11 +135,11 @@ describe Lotus::Utils::Callbacks::Chain do
 
     describe 'when procs are passed' do
       before do
-        @chain.add do
+        @chain.append do
           logger.push 'authenticate!'
         end
 
-        @chain.add do |params|
+        @chain.append do |params|
           logger.push "set_article: #{ params[:id] }"
         end
 
@@ -166,7 +166,7 @@ describe Lotus::Utils::Callbacks::Chain do
     end
 
     it 'raises an error if try to add a callback when frozen' do
-      -> { @chain.add :authenticate! }.must_raise RuntimeError
+      -> { @chain.append :authenticate! }.must_raise RuntimeError
     end
   end
 end


### PR DESCRIPTION
This PR introduces `Chain#append` and `Chain#prepend` as discussed in lotus/controller#76.

The final version is the result of several iterations and benchmarks. I kept all the changes in the repo, along with the benchmarks, so that we can analyse the different implementations.

I'm open to feedback.

The last step is to reintroduce `Chain#add`. However, I have a question. How would you love the method to be tested?

Generally, I test delegation using a stub library. Does it make sense to "clone" all the tests we have for `prepend`? May be no. I think that using a single, generic test (like passing calling the method twice, with a bunch of different versions and checking the result) is sufficient to cover most of the cases.