### PR TITLE
Deprecated Lotus::Utils::Callbacks::Chain#add in favor of #append

### DIFF
--- a/lib/lotus/utils/callbacks.rb
+++ b/lib/lotus/utils/callbacks.rb
@@ -1,3 +1,5 @@
+require 'lotus/utils/deprecation'
+
 module Lotus
   module Utils
     # Before and After callbacks
@@ -21,8 +23,8 @@ module Lotus
 
         # Appends the given callbacks to the end of the chain.
         #
-        # @param callbacks [Array] one or multiple callbacks to add
-        # @param block [Proc] an optional block to be added
+        # @param callbacks [Array] one or multiple callbacks to append
+        # @param block [Proc] an optional block to be appended
         #
         # @return [void]
         #
@@ -41,12 +43,12 @@ module Lotus
         #
         #   chain = Lotus::Utils::Callbacks::Chain.new
         #
-        #   # Add a Proc to be used as a callback, it will be wrapped by `Callback`
+        #   # Append a Proc to be used as a callback, it will be wrapped by `Callback`
         #   # The optional argument(s) correspond to the one passed when invoked the chain with `run`.
         #   chain.append { Authenticator.authenticate! }
         #   chain.append { |params| ArticleRepository.find(params[:id]) }
         #
-        #   # Add a Symbol as a reference to a method name that will be used as a callback.
+        #   # Append a Symbol as a reference to a method name that will be used as a callback.
         #   # It will wrapped by `MethodCallback`
         #   # If the #notificate method accepts some argument(s) they should be passed when `run` is invoked.
         #   chain.append :notificate
@@ -58,7 +60,15 @@ module Lotus
           @chain.uniq!
         end
 
-        alias_method :add, :append
+        # @since 0.1.0
+        # @deprecated Use Lotus::Utils::Callbacks::Chain#append as it has the
+        #   same effect, but it's more consistent with the new API.
+        #
+        # @see Lotus::Utils::Callbacks::Chain#append
+        def add(*callbacks, &blk)
+          Utils::Deprecation.new("Lotus::Utils::Callbacks::Chain#add is deprecated, use #append instead.")
+          append(*callbacks, &blk)
+        end
 
         # Prepends the given callbacks to the beginning of the chain.
         #

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -127,24 +127,32 @@ describe Lotus::Utils::Callbacks::Chain do
   end
 
   describe '#add (#append alias)' do
+    it 'is deprecated' do
+      _, stderr = capture_io do
+        @chain.add :symbolize!
+      end
+
+      stderr.must_match 'Lotus::Utils::Callbacks::Chain#add is deprecated, use #append instead.'
+    end
+
     it 'wraps the given callback with a callable object' do
-      @chain.add :symbolize!
+      capture_io { @chain.add :symbolize! }
 
       cb = @chain.last
       cb.must_respond_to(:call)
     end
 
     it 'adds the callbacks at the end of the chain' do
-      @chain.add(:foo)
+      capture_io { @chain.add(:foo) }
 
-      @chain.add(:bar)
+      capture_io { @chain.add(:bar) }
       @chain.first.callback.must_equal(:foo)
       @chain.last.callback.must_equal(:bar)
     end
 
     describe 'when a callable object is passed' do
       before do
-        @chain.add callback
+        capture_io { @chain.add callback }
       end
 
       let(:callback) { Callable.new }
@@ -157,7 +165,7 @@ describe Lotus::Utils::Callbacks::Chain do
 
     describe 'when a Symbol is passed' do
       before do
-        @chain.add callback
+        capture_io { @chain.add callback }
       end
 
       let(:callback) { :upcase }
@@ -169,14 +177,14 @@ describe Lotus::Utils::Callbacks::Chain do
 
       it 'guarantees unique entries' do
         # add the callback again, see before block
-        @chain.add callback
+        capture_io { @chain.add callback }
         @chain.size.must_equal(1)
       end
     end
 
     describe 'when a block is passed' do
       before do
-        @chain.add(&callback)
+        capture_io { @chain.add(&callback) }
       end
 
       let(:callback) { Proc.new{} }
@@ -189,7 +197,7 @@ describe Lotus::Utils::Callbacks::Chain do
 
     describe 'when multiple callbacks are passed' do
       before do
-        @chain.add(*callbacks)
+        capture_io { @chain.add(*callbacks) }
       end
 
       let(:callbacks) { [:upcase, Callable.new, Proc.new{}] }


### PR DESCRIPTION
Ditto.
---

Now that we have specular API: `#append` and `#prepend` we can get rid of `#add`, which is redundant and ambiguous for the new semantic.

Ref #52 