### PR TITLE
Update .travis.yml for faster runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
+sudo: false
+cache: bundler
 script: 'bundle exec rake test:coverage --trace'
-install:
-  - bundle install --retry=3
 rvm:
   - 2.0.0
   - 2.1.0


### PR DESCRIPTION
The --retry is default on Travis now.
Use Travis container for faster tests.
Cache Bundler downloads.