### PR TITLE
Simplify travis (jruby-head runs 2.2 compatible by default)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,8 @@ rvm:
   - 2.1.5
   - 2.2
   - rbx-2
+  - jruby-head
 
 matrix:
-  include:
-    - rvm: jruby
-      env: JRUBY_OPTS="--2.0"
-    - rvm: jruby-head
-      env: JRUBY_OPTS="--2.1"
   allow_failures:
     - rvm: jruby-head


### PR DESCRIPTION
JRuby fails due to an encoding error, see: jruby/jruby#2581