### PR TITLE
Introduced Utils::String#titleize

### DIFF
--- a/lib/lotus/utils/string.rb
+++ b/lib/lotus/utils/string.rb
@@ -40,6 +40,12 @@ module Lotus
       # @api private
       UNDERSCORE_DIVISION_TARGET  = '\1_\2'.freeze
 
+      # Separator for #titleize
+      #
+      # @since x.x.x
+      # @api private
+      TITLEIZE_SEPARATOR = ' '.freeze
+
       # Initialize the string
       #
       # @param string [::String, Symbol] the value we want to initialize
@@ -49,6 +55,21 @@ module Lotus
       # @since 0.1.0
       def initialize(string)
         @string = string.to_s
+      end
+
+      # Return a titleized version of the string
+      #
+      # @return [Lotus::Utils::String] the transformed string
+      #
+      # @since x.x.x
+      #
+      # @example
+      #   require 'lotus/utils/string'
+      #
+      #   string = Lotus::Utils::String.new 'lotus utils'
+      #   string.titleize # => "Lotus Utils"
+      def titleize
+        self.class.new underscore.split(CLASSIFY_SEPARATOR).map(&:capitalize).join(TITLEIZE_SEPARATOR)
       end
 
       # Return a CamelCase version of the string
@@ -84,6 +105,7 @@ module Lotus
         new_string = gsub(NAMESPACE_SEPARATOR, UNDERSCORE_SEPARATOR)
         new_string.gsub!(/([A-Z\d]+)([A-Z][a-z])/, UNDERSCORE_DIVISION_TARGET)
         new_string.gsub!(/([a-z\d])([A-Z])/, UNDERSCORE_DIVISION_TARGET)
+        new_string.gsub!(/[[:space:]]|\-/, UNDERSCORE_DIVISION_TARGET)
         new_string.downcase!
         self.class.new new_string
       end

--- a/test/string_test.rb
+++ b/test/string_test.rb
@@ -1,7 +1,33 @@
 require 'test_helper'
+require 'lotus/utils'
 require 'lotus/utils/string'
 
 describe Lotus::Utils::String do
+  describe '#titleize' do
+    it 'returns an instance of Lotus::Utils::String' do
+      Lotus::Utils::String.new('lotus').titleize.must_be_kind_of(Lotus::Utils::String)
+    end
+
+    it 'keep self untouched' do
+      string = Lotus::Utils::String.new('lotus')
+      string.titleize
+      string.must_equal 'lotus'
+    end
+
+    it 'returns an titleized string' do
+      Lotus::Utils::String.new('lotus').titleize.must_equal 'Lotus'
+      Lotus::Utils::String.new('LotusUtils').titleize.must_equal  'Lotus Utils'
+      Lotus::Utils::String.new('lotus utils').titleize.must_equal 'Lotus Utils'
+      Lotus::Utils::String.new('lotus_utils').titleize.must_equal 'Lotus Utils'
+      Lotus::Utils::String.new('lotus-utils').titleize.must_equal 'Lotus Utils'
+      Lotus::Utils::String.new("lotus' utils").titleize.must_equal "Lotus' Utils"
+      Lotus::Utils::String.new("lotus’ utils").titleize.must_equal "Lotus’ Utils"
+      Lotus::Utils::String.new("lotus` utils").titleize.must_equal "Lotus` Utils"
+      # Ruby's upcase works only with ASCII chars.
+      # Lotus::Utils::String.new("è vero?").titleize.must_equal "È Vero?"
+    end
+  end
+
   describe '#classify' do
     it 'returns an instance of Lotus::Utils::String' do
       Lotus::Utils::String.new('lotus').classify.must_be_kind_of(Lotus::Utils::String)
@@ -52,6 +78,21 @@ describe Lotus::Utils::String do
     it 'handles numbers' do
       string = Lotus::Utils::String.new('Lucky23Action')
       string.underscore.must_equal 'lucky23_action'
+    end
+
+    it 'handles dashes' do
+      string = Lotus::Utils::String.new('lotus-utils')
+      string.underscore.must_equal 'lotus_utils'
+    end
+
+    it 'handles spaces' do
+      string = Lotus::Utils::String.new('Lotus Utils')
+      string.underscore.must_equal 'lotus_utils'
+    end
+
+    it 'handles accented letters' do
+      string = Lotus::Utils::String.new('è vero')
+      string.underscore.must_equal 'è_vero'
     end
   end
 


### PR DESCRIPTION
## What

`Utils::String#titleize`

## How does it works?

```ruby
require 'lotus/utils/string'

string = Lotus::Utils::String.new 'lotus utils'
string.titleize # => "Lotus Utils"

string = Lotus::Utils::String.new 'lotus-utils'
string.titleize # => "Lotus Utils"

string = Lotus::Utils::String.new 'LotusUtils'
string.titleize # => "Lotus Utils"

# etc..
```

## Why?

This is a supporting feature for Lotus::Helpers' form helper.

```erb
<%=
  form_for(:book, routes.books_path) do
    label :extended_title
    # ...
  end
%>
```

That `label` accepts a symbol that should be titleized to become:

```html
<label for="book-extended-title">Extended Title</label>
```