### PR TITLE
Introduced Utils::String#dasherize

### DIFF
--- a/lib/lotus/utils/string.rb
+++ b/lib/lotus/utils/string.rb
@@ -46,6 +46,12 @@ module Lotus
       # @api private
       TITLEIZE_SEPARATOR = ' '.freeze
 
+      # Separator for #dasherize
+      #
+      # @since x.x.x
+      # @api private
+      DASHERIZE_SEPARATOR = '-'.freeze
+
       # Initialize the string
       #
       # @param string [::String, Symbol] the value we want to initialize
@@ -108,6 +114,27 @@ module Lotus
         new_string.gsub!(/[[:space:]]|\-/, UNDERSCORE_DIVISION_TARGET)
         new_string.downcase!
         self.class.new new_string
+      end
+
+      # Return a downcased and dash separated version of the string
+      #
+      # @return [Lotus::Utils::String] the transformed string
+      #
+      # @since x.x.x
+      #
+      # @example
+      #   require 'lotus/utils/string'
+      #
+      #   string = Lotus::Utils::String.new 'Lotus Utils'
+      #   string.dasherize # => 'lotus-utils'
+      #
+      #   string = Lotus::Utils::String.new 'lotus_utils'
+      #   string.dasherize # => 'lotus-utils'
+      #
+      #   string = Lotus::Utils::String.new 'LotusUtils'
+      #   string.dasherize # => "lotus-utils"
+      def dasherize
+        self.class.new underscore.split(CLASSIFY_SEPARATOR).join(DASHERIZE_SEPARATOR)
       end
 
       # Return the string without the Ruby namespace of the class

--- a/test/string_test.rb
+++ b/test/string_test.rb
@@ -96,6 +96,53 @@ describe Lotus::Utils::String do
     end
   end
 
+  describe '#dasherize' do
+    it 'returns an instance of Lotus::Utils::String' do
+      Lotus::Utils::String.new('Lotus').dasherize.must_be_kind_of(Lotus::Utils::String)
+    end
+
+    it 'keep self untouched' do
+      string = Lotus::Utils::String.new('Lotus')
+      string.dasherize
+      string.must_equal 'Lotus'
+    end
+
+    it 'removes all the upcase characters' do
+      string = Lotus::Utils::String.new('Lotus')
+      string.dasherize.must_equal 'lotus'
+    end
+
+    it 'transforms camel case class names' do
+      string = Lotus::Utils::String.new('LotusView')
+      string.dasherize.must_equal 'lotus-view'
+    end
+
+    it 'handles acronyms' do
+      string = Lotus::Utils::String.new('APIDoc')
+      string.dasherize.must_equal 'api-doc'
+    end
+
+    it 'handles numbers' do
+      string = Lotus::Utils::String.new('Lucky23Action')
+      string.dasherize.must_equal 'lucky23-action'
+    end
+
+    it 'handles underscores' do
+      string = Lotus::Utils::String.new('lotus_utils')
+      string.dasherize.must_equal 'lotus-utils'
+    end
+
+    it 'handles spaces' do
+      string = Lotus::Utils::String.new('Lotus Utils')
+      string.dasherize.must_equal 'lotus-utils'
+    end
+
+    it 'handles accented letters' do
+      string = Lotus::Utils::String.new('è vero')
+      string.dasherize.must_equal 'è-vero'
+    end
+  end
+
   describe '#demodulize' do
     it 'returns an instance of Lotus::Utils::String' do
       Lotus::Utils::String.new('Lotus').demodulize.must_be_kind_of(Lotus::Utils::String)


### PR DESCRIPTION
## What

`Utils::String#dasherize`

## How does it works?

```ruby
require 'lotus/utils/string'

string = Lotus::Utils::String.new 'lotus utils'
string.dasherize # => "lotus-utils"

string = Lotus::Utils::String.new 'lotus_utils'
string.dasherize # => "lotus-utils"

string = Lotus::Utils::String.new 'LotusUtils'
string.dasherize # => "lotus-utils"

# etc..
```

## Why?

This is a supporting feature for Lotus::Helpers' form helper.

```erb
<%=
  form_for(:book, routes.books_path) do
    text_field :extended_title
    # ...
  end
%>
```

That `text_field` accepts a symbol which produces HTML attributes. This new `Utils::String` functionality will be used to produce `id`:

```html
<input type="text" name="book[extended_title]" id="book-extended-title" value="">
```