### PR TITLE
Namespace support for #classify

### DIFF
--- a/lib/lotus/utils/string.rb
+++ b/lib/lotus/utils/string.rb
@@ -32,7 +32,7 @@ module Lotus
       #
       # @since 0.3.0
       # @api private
-      UNDERSCORE_SEPARATOR = "/".freeze
+      UNDERSCORE_SEPARATOR = '/'.freeze
 
       # gsub second parameter used in #underscore
       #
@@ -51,6 +51,12 @@ module Lotus
       # @since x.x.x
       # @api private
       DASHERIZE_SEPARATOR = '-'.freeze
+
+      # Regexp for #classify
+      #
+      # @since 0.3.4
+      # @api private
+      CLASSIFY_WORD_SEPARATOR = /#{CLASSIFY_SEPARATOR}|#{NAMESPACE_SEPARATOR}|#{UNDERSCORE_SEPARATOR}/
 
       # Initialize the string
       #
@@ -90,7 +96,14 @@ module Lotus
       #   string = Lotus::Utils::String.new 'lotus_utils'
       #   string.classify # => 'LotusUtils'
       def classify
-        self.class.new split(CLASSIFY_SEPARATOR).map(&:capitalize).join
+        words = split(CLASSIFY_WORD_SEPARATOR).map(&:capitalize)
+        delimiters = scan(CLASSIFY_WORD_SEPARATOR)
+
+        delimiters.map! do |delimiter|
+          delimiter == CLASSIFY_SEPARATOR ? nil : NAMESPACE_SEPARATOR
+        end
+
+        self.class.new words.zip(delimiters).compact.join
       end
 
       # Return a downcased and underscore separated version of the string

--- a/test/string_test.rb
+++ b/test/string_test.rb
@@ -36,11 +36,16 @@ describe Lotus::Utils::String do
     it 'returns a classified string' do
       Lotus::Utils::String.new('lotus').classify.must_equal('Lotus')
       Lotus::Utils::String.new('lotus_router').classify.must_equal('LotusRouter')
+      Lotus::Utils::String.new('lotus/router').classify.must_equal('Lotus::Router')
+      Lotus::Utils::String.new('lotus::router').classify.must_equal('Lotus::Router')
+      Lotus::Utils::String.new('lotus::router/base_object').classify.must_equal('Lotus::Router::BaseObject')
     end
 
     it 'returns a classified string from symbol' do
       Lotus::Utils::String.new(:lotus).classify.must_equal('Lotus')
       Lotus::Utils::String.new(:lotus_router).classify.must_equal('LotusRouter')
+      Lotus::Utils::String.new(:'lotus/router').classify.must_equal('Lotus::Router')
+      Lotus::Utils::String.new(:'lotus::router').classify.must_equal('Lotus::Router')
     end
   end
 


### PR DESCRIPTION
Made #classify able to handle namespaces delimited by '/' (e.g "lotus/router/mapping".classify # "Lotus::Router::Mapping)