### PR TITLE
Recursively initialize Lotus::Utils::Attributes

### DIFF
--- a/lib/lotus/utils/attributes.rb
+++ b/lib/lotus/utils/attributes.rb
@@ -30,7 +30,7 @@ module Lotus
       #   attributes = Lotus::Utils::Attributes.new(a: 1, b: { 2 => [3, 4] } })
       #   attributes.to_h # => { "a" => 1, "b" => { "2" => [3, 4] } }
       def initialize(hash = {})
-        @attributes = Utils::Hash.new(hash, &nil).stringify!
+        @attributes = self.class.from_hash(hash)
       end
 
       # Get the value associated with the given attribute
@@ -111,6 +111,25 @@ module Lotus
       # @see Lotus::Utils::Hash
       def to_h
         @attributes.deep_dup
+      end
+
+      alias_method :deep_dup, :to_h
+
+      # Returns a stringified version of the hash with each nested hash wrapped
+      # in an Attributes instance
+      #
+      # @param hash [#to_h] a Hash or any object that implements #to_h
+      #
+      # @return [Lotus::Utils::Hash]
+      #
+      # @since x.x.x
+      #
+      # @see Lotus::Utils::Attributes#initialize
+      def self.from_hash(hash)
+        hash.to_h.each_with_object(Utils::Hash.new) do |(k, v), result|
+          v = Attributes.new(v) if v.is_a?(::Hash)
+          result[k.to_s] = v
+        end
       end
     end
   end

--- a/lib/lotus/utils/attributes.rb
+++ b/lib/lotus/utils/attributes.rb
@@ -113,7 +113,14 @@ module Lotus
         @attributes.deep_dup
       end
 
-      alias_method :deep_dup, :to_h
+      # Equality
+      #
+      # @return [TrueClass,FalseClass]
+      #
+      # @since x.x.x
+      def ==(other)
+        @attributes == other.to_h
+      end
 
       # Returns a stringified version of the hash with each nested hash wrapped
       # in an Attributes instance

--- a/lib/lotus/utils/hash.rb
+++ b/lib/lotus/utils/hash.rb
@@ -286,7 +286,7 @@ module Lotus
         case value
         when NilClass, FalseClass, TrueClass, Symbol, Numeric
           value
-        when Hash
+        when Hash, Attributes
           value.deep_dup
         when ::Hash
           Hash.new(value).deep_dup.to_h

--- a/lib/lotus/utils/hash.rb
+++ b/lib/lotus/utils/hash.rb
@@ -286,7 +286,7 @@ module Lotus
         case value
         when NilClass, FalseClass, TrueClass, Symbol, Numeric
           value
-        when Hash, Attributes
+        when Hash
           value.deep_dup
         when ::Hash
           Hash.new(value).deep_dup.to_h

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -28,7 +28,7 @@ describe Lotus::Utils::Attributes do
 
     it 'recursively stringifies keys' do
       attributes = Lotus::Utils::Attributes.new({a: 1, b: { 2 => [3, 4] }})
-      attributes.to_h.must_equal({'a'=>1, 'b'=>{'2'=>[3,4]}})
+      attributes.to_h.must_equal({'a'=>1, 'b'=>Lotus::Utils::Attributes.new({'2'=>[3,4]})})
     end
 
     it 'stores nested hashes as Attributes' do

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -26,9 +26,14 @@ describe Lotus::Utils::Attributes do
       attributes.get('uknown').must_be_nil
     end
 
-    it 'recursively stringify keys' do
+    it 'recursively stringifies keys' do
       attributes = Lotus::Utils::Attributes.new({a: 1, b: { 2 => [3, 4] }})
       attributes.to_h.must_equal({'a'=>1, 'b'=>{'2'=>[3,4]}})
+    end
+
+    it 'stores nested hashes as Attributes' do
+      attributes = Lotus::Utils::Attributes.new({a: 1, b: { 2 => [3, 4] }})
+      attributes.get(:b).class.must_equal Lotus::Utils::Attributes
     end
   end
 


### PR DESCRIPTION
This makes `Lotus::Utils::Attributes` initialization recursive by wrapping any inner hash in another instance of `Utils::Attributes`.

Before:

``` ruby
attrs = Lotus::Utils::Attributes.new(a: { b: 1 })
# => #<Lotus::Utils::Attributes:0x007fe0a1f3f078 @attributes={"a"=>{"b"=>1}}>
attrs[:a][:b]
# => nil
```

After:

``` ruby
attrs = Lotus::Utils::Attributes.new(a: { b: 1 })
# => #<Lotus::Utils::Attributes:0x007fe6623e2ee8 @attributes={"a"=>#<Lotus::Utils::Attributes:0x007fe6623e2dd0 @attributes={"b"=>1}>}>
attrs[:a][:b]
# => 1
```