### PR TITLE
Singularize [WIP]

### DIFF
--- a/lib/lotus/utils/inflector.rb
+++ b/lib/lotus/utils/inflector.rb
@@ -284,6 +284,124 @@ module Lotus
         'trellis'      => 'trellises',
       })
 
+
+      # Irregular rules
+      #
+      # @since x.x.x
+      # @api private
+      SINGULAR_IRREGULAR = IrregularRule.new({
+        # irregular
+        'cacti'   => 'cactus',
+        'children'=> 'child',
+        'corpora' => 'corpus',
+        'feet'    => 'foot',
+        'genera'  => 'genus',
+        'geese'   => 'goose',
+        'men'     => 'man',
+        'oxen'    => 'ox',
+        'people'  => 'person',
+        'quizzes' => 'quiz',
+        'sexes'   => 'sex',
+        'testes'  => 'testis',
+        'teeth'   => 'tooth',
+        'women'   => 'woman',
+        # uncountable
+        'deer'        => 'deer',
+        'equipment'   => 'equipment',
+        'fish'        => 'fish',
+        'information' => 'information',
+        'means'       => 'means',
+        'money'       => 'money',
+        'news'        => 'news',
+        'offspring'   => 'offspring',
+        'rice'        => 'rice',
+        'series'      => 'series',
+        'sheep'       => 'sheep',
+        'species'     => 'species',
+        'police'      => 'police',
+        # ae => a
+        'alumnae'   => 'alumna',
+        'algae'     => 'alga',
+        'vertebrae' => 'vertebra',
+        'personae'  => 'persona',
+        'antennae'  => 'antenna',
+        'formulae'  => 'formula',
+        'nebulae'   => 'nebula',
+        'vitae'     => 'vita',
+        # a = on
+        'criteria'    => 'criterion',
+        'perihelia'   => 'perihelion',
+        'aphelia'     => 'aphelion',
+        'phenomena'   => 'phenomenon',
+        'prolegomena' => 'prolegomenon',
+        'noumena'     => 'noumenon',
+        'organa'      => 'organon',
+        'asyndeta'    => 'asyndeton',
+        'hyperbata'   => 'hyperbaton',
+        # ses => s
+        'acropolises'  => 'acropolis',
+        'chaoses'      => 'chaos',
+        'lenses'       => 'lens',
+        'aegises'      => 'aegis',
+        'cosmoses'     => 'cosmos',
+        'mantises'     => 'mantis',
+        'aliases'      => 'alias',
+        'daises'       => 'dais',
+        'marquises'    => 'marquis',
+        'asbestoses'   => 'asbestos',
+        'digitalises'  => 'digitalis',
+        'metropolises' => 'metropolis',
+        'atlases'      => 'atlas',
+        'epidermises'  => 'epidermis',
+        'pathoses'     => 'pathos',
+        'bathoses'     => 'bathos',
+        'ethoses'      => 'ethos',
+        'pelvises'     => 'pelvis',
+        'biases'       => 'bias',
+        'gases'        => 'gas',
+        'polises'      => 'polis',
+        'caddises'     => 'caddis',
+        'rhinoceroses' => 'rhinoceros',
+        'cannabises'   => 'cannabis',
+        'glottises'    => 'glottis',
+        'sassafrases'  => 'sassafras',
+        'canvases'     => 'canvas',
+        'ibises'       => 'ibis',
+        'trellises'    => 'trellis',
+        # fallback
+        'hives' => 'hive',
+        # ices => ex
+        "codices"    => "codex",
+        "murices"    => "murex",
+        "silices"    => "silex",
+        "apices"     => "apex",
+        "latices"    => "latex",
+        "vertices"   => "vertex",
+        "cortices"   => "cortex",
+        "pontifices" => "pontifex",
+        "vortices"   => "vortex",
+        "indices"    => "index",
+        "simplices"  => "simplex",
+        # ices => ix
+        "radices"    => "radix",
+        "helices"    => "helix",
+        "appendices" => "appendix",
+        # es => is
+        "axes"        => "axis",
+        "analyses"    => "analysis",
+        "bases"       => "basis",
+        "crises"      => "crisis",
+        "diagnoses"   => "diagnosis",
+        "ellipses"    => "ellipsis",
+        "hypotheses"  => "hypothesis",
+        "oases"       => "oasis",
+        "paralyses"   => "paralysis",
+        "parentheses" => "parenthesis",
+        "syntheses"   => "synthesis",
+        "synopses"    => "synopsis",
+        "theses"      => "thesis",
+      })
+
       # Pluralize the given string
       #
       # @param [String] the singular string
@@ -331,6 +449,56 @@ module Lotus
           string
         else
           string + S
+        end
+      end
+
+      # Singularize the given string
+      #
+      # @param [String] the pliral string
+      #
+      # @return [String,NilClass] the singularized string, if present
+      #
+      # @since x.x.x
+      def self.singularize(string)
+        return string if string.nil? || string.match(BLANK_STRING_MATCHER)
+
+        case string
+        when SINGULAR_IRREGULAR
+          SINGULAR_IRREGULAR.apply(string)
+        when /\A.*[^aeiou]#{CHES}\z/
+          string.sub(CHES, 'ch')
+        when /\A.*[^aeiou]#{IES}\z/
+          string.sub(IES, 'y')
+        when /\A(.*)#{ICE}\z/
+          $1 + 'ouse'
+        when /\A.*#{EAUX}\z/
+          string.chop
+        when /\A(.*)ides\z/
+          $1 + 'is'
+        when /\A(.*)us\z/
+          $1 + 'i'
+        when /\A(.*)ses\z/
+          $1 + 's'
+        when /\A(.*)ouse\z/
+          $1 + 'ice'
+        when /\A(.*)mata\z/
+          $1 + 'ma'
+        when /\A(.*)oes\z/
+          $1 + 'o'
+        when /\A(.*)mina\z/
+          $1 + 'men'
+        when /\A(.*)xes\z/
+          $1 + 'x'
+        when /\A(.*)ives\z/
+          $1 + 'ife'
+        when /\A(.*)ves\z/
+          $1 + 'f'
+        when /\A(.*)i\z/
+          $1 + 'us'
+        when /\A(.*)a\z/
+          $1 + 'um'
+        else
+          string.chop
         end
       end
     end

--- a/lib/lotus/utils/inflector.rb
+++ b/lib/lotus/utils/inflector.rb
@@ -3,6 +3,7 @@ module Lotus
     # String inflector
     #
     # @since x.x.x
+    # @api private
     module Inflector
       # Rule for irregular plural
       #
@@ -65,11 +66,27 @@ module Lotus
 
       # @since x.x.x
       # @api private
+      A    = 'a'.freeze
+
+      # @since x.x.x
+      # @api private
+      CH   = 'ch'.freeze
+
+      # @since x.x.x
+      # @api private
       CHES = 'ches'.freeze
 
       # @since x.x.x
       # @api private
-      IES  = 'ies'.freeze
+      EAUX = 'eaux'.freeze
+
+      # @since x.x.x
+      # @api private
+      F    = 'f'.freeze
+
+      # @since x.x.x
+      # @api private
+      I    = 'i'.freeze
 
       # @since x.x.x
       # @api private
@@ -81,15 +98,15 @@ module Lotus
 
       # @since x.x.x
       # @api private
-      XES  = 'xes'.freeze
+      IDES = 'ides'.freeze
 
       # @since x.x.x
       # @api private
-      A    = 'a'.freeze
+      IES  = 'ies'.freeze
 
       # @since x.x.x
       # @api private
-      EAUX = 'eaux'.freeze
+      IFE  = 'ife'.freeze
 
       # @since x.x.x
       # @api private
@@ -97,7 +114,47 @@ module Lotus
 
       # @since x.x.x
       # @api private
-      VES  = 'ves'.freeze
+      IS   = 'is'.freeze
+
+      # @since x.x.x
+      # @api private
+      IVES = 'ives'.freeze
+
+      # @since x.x.x
+      # @api private
+      MA   = 'ma'.freeze
+
+      # @since x.x.x
+      # @api private
+      MATA = 'mata'.freeze
+
+      # @since x.x.x
+      # @api private
+      MEN  = 'men'.freeze
+
+      # @since x.x.x
+      # @api private
+      MINA = 'mina'.freeze
+
+      # @since x.x.x
+      # @api private
+      O    = 'o'.freeze
+
+      # @since x.x.x
+      # @api private
+      OES  = 'oes'.freeze
+
+      # @since x.x.x
+      # @api private
+      OUSE = 'ouse'.freeze
+
+      # @since x.x.x
+      # @api private
+      S    = 's'.freeze
+
+      # @since x.x.x
+      # @api private
+      SES  = 'ses'.freeze
 
       # @since x.x.x
       # @api private
@@ -105,11 +162,31 @@ module Lotus
 
       # @since x.x.x
       # @api private
+      UM   = 'um'.freeze
+
+      # @since x.x.x
+      # @api private
+      US   = 'us'.freeze
+
+      # @since x.x.x
+      # @api private
       USES = 'uses'.freeze
 
       # @since x.x.x
       # @api private
-      S    = 's'.freeze
+      VES  = 'ves'.freeze
+
+      # @since x.x.x
+      # @api private
+      X    = 'x'.freeze
+
+      # @since x.x.x
+      # @api private
+      XES  = 'xes'.freeze
+
+      # @since x.x.x
+      # @api private
+      Y    = 'y'.freeze
 
       # Plural rule "is" => "es"
       #
@@ -284,7 +361,6 @@ module Lotus
         'trellis'      => 'trellises',
       })
 
-
       # Irregular rules
       #
       # @since x.x.x
@@ -408,6 +484,7 @@ module Lotus
       #
       # @return [String,NilClass] the pluralized string, if present
       #
+      # @api private
       # @since x.x.x
       def self.pluralize(string)
         return string if string.nil? || string.match(BLANK_STRING_MATCHER)
@@ -458,6 +535,7 @@ module Lotus
       #
       # @return [String,NilClass] the singularized string, if present
       #
+      # @api private
       # @since x.x.x
       def self.singularize(string)
         return string if string.nil? || string.match(BLANK_STRING_MATCHER)
@@ -466,37 +544,37 @@ module Lotus
         when SINGULAR_IRREGULAR
           SINGULAR_IRREGULAR.apply(string)
         when /\A.*[^aeiou]#{CHES}\z/
-          string.sub(CHES, 'ch')
+          string.sub(CHES, CH)
         when /\A.*[^aeiou]#{IES}\z/
-          string.sub(IES, 'y')
+          string.sub(IES, Y)
         when /\A(.*)#{ICE}\z/
-          $1 + 'ouse'
+          $1 + OUSE
         when /\A.*#{EAUX}\z/
           string.chop
-        when /\A(.*)ides\z/
-          $1 + 'is'
-        when /\A(.*)us\z/
-          $1 + 'i'
-        when /\A(.*)ses\z/
-          $1 + 's'
-        when /\A(.*)ouse\z/
-          $1 + 'ice'
-        when /\A(.*)mata\z/
-          $1 + 'ma'
-        when /\A(.*)oes\z/
-          $1 + 'o'
-        when /\A(.*)mina\z/
-          $1 + 'men'
-        when /\A(.*)xes\z/
-          $1 + 'x'
-        when /\A(.*)ives\z/
-          $1 + 'ife'
-        when /\A(.*)ves\z/
-          $1 + 'f'
-        when /\A(.*)i\z/
-          $1 + 'us'
-        when /\A(.*)a\z/
-          $1 + 'um'
+        when /\A(.*)#{IDES}\z/
+          $1 + IS
+        when /\A(.*)#{US}\z/
+          $1 + I
+        when /\A(.*)#{SES}\z/
+          $1 + S
+        when /\A(.*)#{OUSE}\z/
+          $1 + ICE
+        when /\A(.*)#{MATA}\z/
+          $1 + MA
+        when /\A(.*)#{OES}\z/
+          $1 + O
+        when /\A(.*)#{MINA}\z/
+          $1 + MEN
+        when /\A(.*)#{XES}\z/
+          $1 + X
+        when /\A(.*)#{IVES}\z/
+          $1 + IFE
+        when /\A(.*)#{VES}\z/
+          $1 + F
+        when /\A(.*)#{I}\z/
+          $1 + US
+        when /\A(.*)#{A}\z/
+          $1 + UM
         when /[^s]\z/
           string
         else

--- a/lib/lotus/utils/inflector.rb
+++ b/lib/lotus/utils/inflector.rb
@@ -497,6 +497,8 @@ module Lotus
           $1 + 'us'
         when /\A(.*)a\z/
           $1 + 'um'
+        when /[^s]\z/
+          string
         else
           string.chop
         end

--- a/lib/lotus/utils/string.rb
+++ b/lib/lotus/utils/string.rb
@@ -226,6 +226,7 @@ module Lotus
       #
       # @return [Lotus::Utils::String] the pluralized string.
       #
+      # @api private
       # @since x.x.x
       #
       # @see Lotus::Utils::Inflector
@@ -237,6 +238,7 @@ module Lotus
       #
       # @return [Lotus::Utils::String] the singularized string.
       #
+      # @api private
       # @since x.x.x
       #
       # @see Lotus::Utils::Inflector

--- a/lib/lotus/utils/string.rb
+++ b/lib/lotus/utils/string.rb
@@ -233,6 +233,17 @@ module Lotus
         self.class.new Inflector.pluralize(self)
       end
 
+      # Return a singularized version of self.
+      #
+      # @return [Lotus::Utils::String] the singularized string.
+      #
+      # @since x.x.x
+      #
+      # @see Lotus::Utils::Inflector
+      def singularize
+        self.class.new Inflector.singularize(self)
+      end
+
       # Returns the hash of the internal string
       #
       # @return [Fixnum]

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -614,3 +614,5 @@ TEST_PLURALS = {
   "car"          => "cars",
   "hive"         => "hives",
 }.freeze
+
+TEST_SINGULAR = TEST_PLURALS

--- a/test/inflector_test.rb
+++ b/test/inflector_test.rb
@@ -54,4 +54,56 @@ describe Lotus::Utils::Inflector do
       end
     end
   end
+
+  describe '.singularize' do
+    it "returns nil when nil is given" do
+      actual = Lotus::Utils::Inflector.singularize(nil)
+      actual.must_be_nil
+    end
+
+    it "returns empty string when empty string is given" do
+      actual = Lotus::Utils::Inflector.singularize("")
+      actual.must_be_empty
+    end
+
+    it "returns empty string when empty string is given (multiple chars)" do
+      actual = Lotus::Utils::Inflector.singularize(string = "   ")
+      actual.must_equal string
+    end
+
+    it "returns instance of String" do
+      result = Lotus::Utils::Inflector.singularize("Lotus")
+      result.class.must_equal ::String
+    end
+
+    it "doesn't modify original string" do
+      string = "application"
+      result = Lotus::Utils::Inflector.singularize(string)
+
+      result.object_id.wont_equal(string.object_id)
+      string.must_equal("application")
+    end
+  end
+
+    TEST_SINGULAR.each do |singular, plural|
+      it %(singularizes "#{ plural }" to "#{ singular }") do
+        actual = Lotus::Utils::Inflector.singularize(plural)
+        actual.must_equal singular
+      end
+
+      it %(singularizes titleized "#{ Lotus::Utils::String.new(plural).titleize }" to "#{ singular }") do
+        actual = Lotus::Utils::Inflector.singularize(Lotus::Utils::String.new(plural).titleize)
+        actual.must_equal Lotus::Utils::String.new(singular).titleize
+      end
+
+      # it %(doesn't singularizes "#{ singular }" as it's already singular) do
+      #   actual = Lotus::Utils::Inflector.singularize(singular)
+      #   actual.must_equal singular
+      # end
+
+      # it %(doesn't singularizes titleized "#{ Lotus::Utils::String.new(plural).titleize }" as it's already singular) do
+      #   actual = Lotus::Utils::Inflector.singularize(Lotus::Utils::String.new(singular).titleize)
+      #   actual.must_equal Lotus::Utils::String.new(singular).titleize
+      # end
+    end
 end

--- a/test/inflector_test.rb
+++ b/test/inflector_test.rb
@@ -72,16 +72,16 @@ describe Lotus::Utils::Inflector do
     end
 
     it "returns instance of String" do
-      result = Lotus::Utils::Inflector.singularize("Lotus")
+      result = Lotus::Utils::Inflector.singularize("application")
       result.class.must_equal ::String
     end
 
     it "doesn't modify original string" do
-      string = "application"
+      string = "applications"
       result = Lotus::Utils::Inflector.singularize(string)
 
       result.object_id.wont_equal(string.object_id)
-      string.must_equal("application")
+      string.must_equal("applications")
     end
   end
 


### PR DESCRIPTION
## Feature

Introduce singularization for strings.

## How

It adds a new public API method: Utils::String#singularize, which returns a new singularized instance of the same type.

```ruby
string = Lotus::Utils::String.new("flowers")
string.singularize       # => "flower"
string.singularize.class # => Lotus::Utils::String
```

The implementation is delegated to a new module: Lotus::Utils::Inflector. It exposes .singularize which works with Ruby's String.

```ruby
Lotus::Utils::Inflector.singularize("flowers")       # => "flower"
Lotus::Utils::Inflector.singularize("flowers").class # => String
```

Sigunlaritazion is idempotent.

```ruby
Lotus::Utils::Inflector.singularize(
  Lotus::Utils::Inflector.singularize("user")
) # => "user"
```

It respects the case:

```ruby
Lotus::Utils::Inflector.singularize("Applications") # => "Application"
```