### PR TITLE
Add missing Lotus::Interactor include in examples

### DIFF
--- a/lib/lotus/interactor.rb
+++ b/lib/lotus/interactor.rb
@@ -176,6 +176,8 @@ module Lotus
       #   require 'lotus/interactor'
       #
       #   class Signup
+      #     include Lotus::Interactor
+      #
       #     def initialize(params)
       #       @params = params
       #       @user   = User.new(@params)
@@ -198,6 +200,8 @@ module Lotus
       #   require 'lotus/interactor'
       #
       #   class Signup
+      #     include Lotus::Interactor
+      #
       #     def initialize(params)
       #       @params = params
       #       @user   = User.new(@params)


### PR DESCRIPTION
Just two module includes I suspect are missing in the examples for Lotus::Interactor.