### PR TITLE
When coerce Utils::Attributes to Hash don't rely on #to_h of the single values

### DIFF
--- a/lib/lotus/utils/attributes.rb
+++ b/lib/lotus/utils/attributes.rb
@@ -123,7 +123,7 @@ module Lotus
       # @api private
       def _read_value(value)
         case val = value
-        when ->(v) { !v.nil? && v.respond_to?(:to_h) }
+        when ::Hash, ::Lotus::Utils::Hash, ->(v) { v.respond_to?(:lotus_nested_attributes?) }
           Utils::Hash.new(val)
         else
           val

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -147,6 +147,10 @@ describe Lotus::Utils::Attributes do
   describe '#to_h' do
     before do
       @value = Class.new do
+        def lotus_nested_attributes?
+          true
+        end
+
         def to_h
           {'foo' => 'bar'}
         end
@@ -171,12 +175,22 @@ describe Lotus::Utils::Attributes do
       actual.get('b').must_be_nil
     end
 
-    it 'forces ::Lotus::Utils::Hash values' do
+    it 'forces ::Lotus::Utils::Hash values when a validations nested attributes is given' do
       attributes = Lotus::Utils::Attributes.new(val: @value)
       actual     = attributes.to_h
 
       actual.must_equal({'val' => { 'foo' => 'bar'}})
       actual['val'].must_be_kind_of(Lotus::Utils::Hash)
+    end
+
+    # Bug
+    # See: https://github.com/lotus/validations/issues/58#issuecomment-99144243
+    it 'fallbacks to the original value if TypeError is raised' do
+      attributes = Lotus::Utils::Attributes.new(val: [1, 2])
+      actual     = attributes.to_h
+
+      actual.must_equal({'val' => [1, 2]})
+      actual['val'].must_be_kind_of(Array)
     end
   end
 end


### PR DESCRIPTION
Only convert `::Hash`, `Utils::Hash` and `Lotus::Validations::NestedAttributes`.

Ref https://github.com/lotus/validations/issues/58