### PR TITLE
Make TypeError messages even more useful

### DIFF
--- a/lib/lotus/utils/kernel.rb
+++ b/lib/lotus/utils/kernel.rb
@@ -140,7 +140,7 @@ module Lotus
           Set.new(::Kernel.Array(arg))
         end
       rescue NoMethodError
-        raise TypeError.new("can't convert into Set")
+        raise TypeError.new("can't convert #{inspect_type_error(arg)}into Set")
       end
 
       # Coerces the argument to be a Hash.
@@ -205,7 +205,7 @@ module Lotus
             super(arg)
           end
         rescue NoMethodError
-          raise TypeError.new "can't convert into Hash"
+          raise TypeError.new "can't convert #{inspect_type_error(arg)}into Hash"
         end
       else
         def self.Hash(arg)
@@ -217,7 +217,7 @@ module Lotus
             super(arg)
           end
         rescue ArgumentError, NoMethodError
-          raise TypeError.new "can't convert into Hash"
+          raise TypeError.new "can't convert #{inspect_type_error(arg)}into Hash"
         end
       end
 
@@ -336,13 +336,13 @@ module Lotus
           when NilClass, ->(a) { a.respond_to?(:to_i) && a.to_s.match(NUMERIC_MATCHER) }
             arg.to_i
           else
-            raise TypeError.new "can't convert into Integer"
+            raise TypeError.new "can't convert #{inspect_type_error(arg)}into Integer"
           end
         rescue NoMethodError
-          raise TypeError.new "can't convert into Integer"
+          raise TypeError.new "can't convert #{inspect_type_error(arg)}into Integer"
         end
       rescue RangeError
-        raise TypeError.new "can't convert into Integer"
+        raise TypeError.new "can't convert #{inspect_type_error(arg)}into Integer"
       end
 
       # Coerces the argument to be a BigDecimal.
@@ -426,10 +426,10 @@ module Lotus
         when ->(a) { a.to_s.match(NUMERIC_MATCHER) }
           BigDecimal.new(arg)
         else
-          raise TypeError.new "can't convert into BigDecimal"
+          raise TypeError.new "can't convert #{inspect_type_error(arg)}into BigDecimal"
         end
       rescue NoMethodError
-        raise TypeError.new "can't convert into BigDecimal"
+        raise TypeError.new "can't convert #{inspect_type_error(arg)}into BigDecimal"
       end
 
       # Coerces the argument to be a Float.
@@ -552,13 +552,13 @@ module Lotus
           when NilClass, ->(a) { a.respond_to?(:to_f) && a.to_s.match(NUMERIC_MATCHER) }
             arg.to_f
           else
-            raise TypeError.new "can't convert into Float"
+            raise TypeError.new "can't convert #{inspect_type_error(arg)}into Float"
           end
         rescue NoMethodError
-          raise TypeError.new "can't convert into Float"
+          raise TypeError.new "can't convert #{inspect_type_error(arg)}into Float"
         end
       rescue RangeError
-        raise TypeError.new "can't convert into Float"
+        raise TypeError.new "can't convert #{inspect_type_error(arg)}into Float"
       end
 
       # Coerces the argument to be a String.
@@ -659,14 +659,14 @@ module Lotus
             super(arg)
           end
         rescue NoMethodError
-          raise TypeError.new "can't convert into String"
+          raise TypeError.new "can't convert #{inspect_type_error(arg)}into String"
         end
       else
         def self.String(arg)
           arg = arg.to_str if arg.respond_to?(:to_str)
           super(arg)
         rescue NoMethodError
-          raise TypeError.new "can't convert into String"
+          raise TypeError.new "can't convert #{inspect_type_error(arg)}into String"
         end
       end
 
@@ -731,7 +731,7 @@ module Lotus
           Date.parse(arg.to_s)
         end
       rescue ArgumentError, NoMethodError
-        raise TypeError.new "can't convert into Date"
+        raise TypeError.new "can't convert #{inspect_type_error(arg)}into Date"
       end
 
       # Coerces the argument to be a DateTime.
@@ -799,7 +799,7 @@ module Lotus
           DateTime.parse(arg.to_s)
         end
       rescue ArgumentError, NoMethodError
-        raise TypeError.new "can't convert into DateTime"
+        raise TypeError.new "can't convert #{inspect_type_error(arg)}into DateTime"
       end
 
       # Coerces the argument to be a Time.
@@ -864,7 +864,7 @@ module Lotus
           Time.parse(arg.to_s)
         end
       rescue ArgumentError, NoMethodError
-        raise TypeError.new "can't convert into Time"
+        raise TypeError.new "can't convert #{inspect_type_error(arg)}into Time"
       end
 
       # Coerces the argument to be a Boolean.
@@ -917,7 +917,7 @@ module Lotus
           !!arg
         end
       rescue NoMethodError
-        raise TypeError.new "can't convert into Boolean"
+        raise TypeError.new "can't convert #{inspect_type_error(arg)}into Boolean"
       end
 
       # Coerces the argument to be a Pathname.
@@ -975,7 +975,7 @@ module Lotus
           super
         end
       rescue NoMethodError
-        raise TypeError.new "can't convert into Pathname"
+        raise TypeError.new "can't convert #{inspect_type_error(arg)}into Pathname"
       end
 
       # Coerces the argument to be a String.
@@ -1021,13 +1021,41 @@ module Lotus
       #   Lotus::Utils::Kernel.Symbol(input) # => TypeError
       def self.Symbol(arg)
         case arg
-        when '' then raise TypeError.new "can't convert into Symbol"
+        when '' then raise TypeError.new "can't convert #{inspect_type_error(arg)}into Symbol"
         when ->(a) { a.respond_to?(:to_sym) } then arg.to_sym
         else
-          raise TypeError.new "can't convert into Symbol"
+          raise TypeError.new "can't convert #{inspect_type_error(arg)}into Symbol"
         end
       rescue NoMethodError
-        raise TypeError.new "can't convert into Symbol"
+        raise TypeError.new "can't convert #{inspect_type_error(arg)}into Symbol"
+      end
+
+      class << self
+        # Returns the most useful type error possible
+        #
+        # If the object does not respond_to?(:inspect), we return the class, else we
+        # return nil. In all cases, this method is tightly bound to callers, as this
+        # method appends the required space to make the error message look good.
+        #
+        # Used internally by Lotus::Utils::Kernel. This method is not part of the public
+        # API.
+        #
+        # @since x.x.x
+        #
+        # @api private
+        def inspect_type_error(arg)
+          (arg.respond_to?(:inspect) ? arg.inspect : arg.to_s) << " "
+        rescue NoMethodError => _
+          # missing the #respond_to? method, fall back to returning the class' name
+          begin
+            arg.class.name << " instance "
+          rescue NoMethodError => _
+            # missing the #class method, can't fall back to anything better than nothing
+            # Callers will have to guess from their code
+            nil
+          end
+        end
+        private :inspect_type_error
       end
     end
   end

--- a/test/kernel_test.rb
+++ b/test/kernel_test.rb
@@ -630,7 +630,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Integer(input)
           rescue => e
-            e.message.must_equal "can't convert into Integer"
+            e.message.must_equal "can't convert #{input.inspect} into Integer"
           end
         end
       end
@@ -654,7 +654,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Integer(input)
           rescue => e
-            e.message.must_equal "can't convert into Integer"
+            e.message.must_equal "can't convert #{input.inspect} into Integer"
           end
         end
       end
@@ -670,7 +670,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Integer(input)
           rescue => e
-            e.message.must_equal "can't convert into Integer"
+            e.message.must_equal "can't convert #{input.inspect} into Integer"
           end
         end
       end
@@ -686,7 +686,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Integer(input)
           rescue => e
-            e.message.must_equal "can't convert into Integer"
+            e.message.must_equal "can't convert #{input.inspect} into Integer"
           end
         end
       end
@@ -696,7 +696,7 @@ describe Lotus::Utils::Kernel do
 
         it 'raises error' do
           exception = -> { Lotus::Utils::Kernel.Integer(input) }.must_raise(TypeError)
-          exception.message.must_equal "can't convert into Integer"
+          exception.message.must_equal "can't convert #{input.inspect} into Integer"
         end
       end
 
@@ -705,7 +705,7 @@ describe Lotus::Utils::Kernel do
 
         it 'raises error' do
           exception = -> { Lotus::Utils::Kernel.Integer(input) }.must_raise(TypeError)
-          exception.message.must_equal "can't convert into Integer"
+          exception.message.must_equal "can't convert #{input.inspect} into Integer"
         end
       end
     end
@@ -920,7 +920,7 @@ describe Lotus::Utils::Kernel do
 
         it 'raises error' do
           exception = -> { Lotus::Utils::Kernel.BigDecimal(input) }.must_raise(TypeError)
-          exception.message.must_equal "can't convert into BigDecimal"
+          exception.message.must_equal "can't convert #{input.inspect} into BigDecimal"
         end
       end
 
@@ -929,7 +929,7 @@ describe Lotus::Utils::Kernel do
 
         it 'raises error' do
           exception = -> { Lotus::Utils::Kernel.BigDecimal(input) }.must_raise(TypeError)
-          exception.message.must_equal "can't convert into BigDecimal"
+          exception.message.must_equal "can't convert #{input.inspect} into BigDecimal"
         end
       end
 
@@ -1155,7 +1155,7 @@ describe Lotus::Utils::Kernel do
 
         it 'raises error' do
           exception = -> { Lotus::Utils::Kernel.Float(input) }.must_raise(TypeError)
-          exception.message.must_equal "can't convert into Float"
+          exception.message.must_equal "can't convert #{input.inspect} into Float"
         end
       end
 
@@ -1164,7 +1164,7 @@ describe Lotus::Utils::Kernel do
 
         it 'raises error' do
           exception = -> { Lotus::Utils::Kernel.Float(input) }.must_raise(TypeError)
-          exception.message.must_equal "can't convert into Float"
+          exception.message.must_equal "can't convert #{input.inspect} into Float"
         end
       end
 
@@ -1203,7 +1203,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Float(input)
           rescue => e
-            e.message.must_equal "can't convert into Float"
+            e.message.must_equal "can't convert #{input.inspect} into Float"
           end
         end
       end
@@ -1219,7 +1219,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Float(input)
           rescue => e
-            e.message.must_equal "can't convert into Float"
+            e.message.must_equal "can't convert #{input.inspect} into Float"
           end
         end
       end
@@ -1729,7 +1729,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Date(input)
           rescue => e
-            e.message.must_equal "can't convert into Date"
+            e.message.must_equal "can't convert #{input.inspect} into Date"
           end
         end
       end
@@ -1745,7 +1745,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Date(input)
           rescue => e
-            e.message.must_equal "can't convert into Date"
+            e.message.must_equal "can't convert #{input.inspect} into Date"
           end
         end
       end
@@ -1761,7 +1761,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Date(input)
           rescue => e
-            e.message.must_equal "can't convert into Date"
+            e.message.must_equal "can't convert #{input.inspect} into Date"
           end
         end
       end
@@ -1777,7 +1777,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Date(input)
           rescue => e
-            e.message.must_equal "can't convert into Date"
+            e.message.must_equal "can't convert #{input.inspect} into Date"
           end
         end
       end
@@ -1793,7 +1793,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Date(input)
           rescue => e
-            e.message.must_equal "can't convert into Date"
+            e.message.must_equal "can't convert #{input.inspect} into Date"
           end
         end
       end
@@ -1809,7 +1809,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Date(input)
           rescue => e
-            e.message.must_equal "can't convert into Date"
+            e.message.must_equal "can't convert #{input.inspect} into Date"
           end
         end
       end
@@ -1825,7 +1825,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Date(input)
           rescue => e
-            e.message.must_equal "can't convert into Date"
+            e.message.must_equal "can't convert #{input.inspect} into Date"
           end
         end
       end
@@ -1974,7 +1974,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.DateTime(input)
           rescue => e
-            e.message.must_equal "can't convert into DateTime"
+            e.message.must_equal "can't convert #{input.inspect} into DateTime"
           end
         end
       end
@@ -1990,7 +1990,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.DateTime(input)
           rescue => e
-            e.message.must_equal "can't convert into DateTime"
+            e.message.must_equal "can't convert #{input.inspect} into DateTime"
           end
         end
       end
@@ -2006,7 +2006,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.DateTime(input)
           rescue => e
-            e.message.must_equal "can't convert into DateTime"
+            e.message.must_equal "can't convert #{input.inspect} into DateTime"
           end
         end
       end
@@ -2022,7 +2022,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.DateTime(input)
           rescue => e
-            e.message.must_equal "can't convert into DateTime"
+            e.message.must_equal "can't convert #{input.inspect} into DateTime"
           end
         end
       end
@@ -2171,7 +2171,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Time(input)
           rescue => e
-            e.message.must_equal "can't convert into Time"
+            e.message.must_equal "can't convert #{input.inspect} into Time"
           end
         end
       end
@@ -2187,7 +2187,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Time(input)
           rescue => e
-            e.message.must_equal "can't convert into Time"
+            e.message.must_equal "can't convert #{input.inspect} into Time"
           end
         end
       end
@@ -2203,7 +2203,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Time(input)
           rescue => e
-            e.message.must_equal "can't convert into Time"
+            e.message.must_equal "can't convert #{input.inspect} into Time"
           end
         end
       end
@@ -2219,7 +2219,7 @@ describe Lotus::Utils::Kernel do
           begin
             Lotus::Utils::Kernel.Time(input)
           rescue => e
-            e.message.must_equal "can't convert into Time"
+            e.message.must_equal "can't convert #{input.inspect} into Time"
           end
         end
       end


### PR DESCRIPTION
I was struck by a `TypeError` with no information about what went wrong:

```
TypeError: can't convert into Integer
```

The backtrace led me nowhere as this was all framework code. The last code that belonged to me was the call to `Repository#create`. After that, it was all library code. See https://gist.github.com/francois/283f9ee23d268b69aa60 for a sample backtrace.

Now, I get a much more useful error message:

```
TypeError: can't convert #<Date: 2015-04-20 ((2457133j,0s,0n),+0s,2299161j)> into Integer
```
