### PR TITLE
Interactor improvements

### DIFF
--- a/lib/lotus/interactor.rb
+++ b/lib/lotus/interactor.rb
@@ -29,6 +29,7 @@ module Lotus
       # @api private
       def initialize(payload = {})
         @payload = _payload(payload)
+        @errors  = []
         @success = true
       end
 
@@ -59,7 +60,14 @@ module Lotus
       # @see Lotus::Interactor#error
       # @see Lotus::Interactor#error!
       def errors
-        @payload.fetch(:_errors) { [] }
+        @errors.dup
+      end
+
+      # @since x.x.x
+      # @api private
+      def add_error(*errors)
+        @errors << errors
+        @errors.flatten!
       end
 
       # Returns the first errors collected during an operation
@@ -161,7 +169,6 @@ module Lotus
         super
       ensure
         @__result = ::Lotus::Interactor::Result.new
-        @_errors  = []
       end
 
       # Triggers the operation and return a result.
@@ -343,7 +350,7 @@ module Lotus
     #   result.errors # => ["Prepare data error", "Persist error"]
     #   result.logger # => [:prepare_data!, :persist!, :sync!]
     def error(message)
-      @_errors << message
+      @__result.add_error << message
       false
     end
 
@@ -444,8 +451,6 @@ module Lotus
 
         class_attribute :exposures
         self.exposures = Utils::Hash.new
-
-        expose :_errors
       end
     end
 

--- a/test/interactor_test.rb
+++ b/test/interactor_test.rb
@@ -32,6 +32,7 @@ end
 
 class Signup
   include Lotus::Interactor
+  expose :user, :params
 
   def initialize(params)
     @params  = params
@@ -53,6 +54,7 @@ end
 
 class ErrorInteractor
   include Lotus::Interactor
+  expose :operations
 
   def initialize
     @operations = []
@@ -82,6 +84,7 @@ end
 
 class ErrorBangInteractor
   include Lotus::Interactor
+  expose :operations
 
   def initialize
     @operations = []
@@ -124,6 +127,7 @@ end
 
 class CreateUser
   include Lotus::Interactor
+  expose :user
 
   def initialize(params)
     @user = User.new(params)

--- a/test/interactor_test.rb
+++ b/test/interactor_test.rb
@@ -285,7 +285,7 @@ describe Lotus::Interactor::Result do
     describe "when it has errors" do
       it "isn't successful" do
         result = Lotus::Interactor::Result.new
-        result.prepare!(_errors: ["There was a problem"])
+        result.add_error "There was a problem"
         assert !result.success?, "Expected `result' to NOT be successful"
       end
     end
@@ -324,7 +324,16 @@ describe Lotus::Interactor::Result do
 
     it "returns all the errors" do
       result = Lotus::Interactor::Result.new
-      result.prepare!(_errors: ['Error 1', 'Error 2'])
+      result.add_error ['Error 1', 'Error 2']
+
+      result.errors.must_equal ['Error 1', 'Error 2']
+    end
+
+    it "prevents information escape" do
+      result = Lotus::Interactor::Result.new
+      result.add_error ['Error 1', 'Error 2']
+
+      result.errors.clear
 
       result.errors.must_equal ['Error 1', 'Error 2']
     end
@@ -338,7 +347,7 @@ describe Lotus::Interactor::Result do
 
     it "returns only the first error" do
       result = Lotus::Interactor::Result.new
-      result.prepare!(_errors: ['Error 1', 'Error 2'])
+      result.add_error ['Error 1', 'Error 2']
 
       result.error.must_equal 'Error 1'
     end


### PR DESCRIPTION
This is a proposal for a few `Lotus::Interactor` improvements.

:warning: **The following change isn't backward compatible** :warning: 

--

### Remove magic :sparkles: in favor of explicitness

Until now all the instance variables from an interactor were automatically exposed into the returning value of `#call`, which is an instance of `Lotus::Interactor::Result`.

#### Before

```ruby
class Signup
  include Lotus::Interactor

  def initialize(params)
    @params = params
    @user = User.new(params.fetch(:user))
  end

  def call
    # ...
  end
end

result = Signup.new(user: { name: "Luca" }).call

result.user   # => #<User:0x007fa311105778 @id=1 @name="Luca">
result.params # => { :user=>{:name=>"Luca"} }
```

#### After

```ruby
class Signup
  include Lotus::Interactor
  expose :user

  def initialize(params)
    @params = params
    @user = User.new(params.fetch(:user))
  end
end

result = Signup.new(user: { name: "Luca" }).call

result.user   # => #<User:0x007fa311105778 @id=1 @name="Luca">
result.params # => raises NoMethodError because we haven't exposed it
```

---

/cc @lotus/core-team @AlfonsoUceda @luislavena 

Closes #77 