### PR TITLE
Bug in PathPrefix's relative_join

### DIFF
--- a/lib/lotus/utils/path_prefix.rb
+++ b/lib/lotus/utils/path_prefix.rb
@@ -82,7 +82,7 @@ module Lotus
         prefix = @string.gsub(@separator, separator)
 
         self.class.new(
-          [prefix, strings].join(separator).chomp("/"),
+          [prefix, strings].join(separator).chomp(separator),
           separator
         ).relative!
       end

--- a/lib/lotus/utils/path_prefix.rb
+++ b/lib/lotus/utils/path_prefix.rb
@@ -82,7 +82,7 @@ module Lotus
         prefix = @string.gsub(@separator, separator)
 
         self.class.new(
-          [prefix, strings].join(separator).chomp(separator),
+          [prefix, strings].flatten.compact.join(separator),
           separator
         ).relative!
       end

--- a/lib/lotus/utils/path_prefix.rb
+++ b/lib/lotus/utils/path_prefix.rb
@@ -82,7 +82,7 @@ module Lotus
         prefix = @string.gsub(@separator, separator)
 
         self.class.new(
-          Utils::Kernel.Array([prefix, strings]).join(separator),
+          [prefix, strings].join(separator).chomp("/"),
           separator
         ).relative!
       end

--- a/test/path_prefix_test.rb
+++ b/test/path_prefix_test.rb
@@ -29,6 +29,11 @@ describe Lotus::Utils::PathPrefix do
       prefix.join('/cherries').must_equal '/fruits/cherries'
     end
 
+    it 'joins a string that is the same as the prefix' do
+      prefix = Lotus::Utils::PathPrefix.new('fruits')
+      prefix.join('fruits').must_equal '/fruits/fruits'
+    end
+
     it 'joins a string when the root is blank' do
       prefix = Lotus::Utils::PathPrefix.new
       prefix.join('tea').must_equal '/tea'


### PR DESCRIPTION
This is an issue i tracked back to from the router.

So given this prefix:
```
prefix = Lotus::Utils::PathPrefix.new('fruits')
```

when joined with the same string

```
prefix.join('fruits') # => /fruits
```
will get rid of one of them only keeping the above `/fruits` instead of `/fruits/fruits`

Obviously that shouldn't be the case because we should be able to have paths such as `/fruits/fruits/fruits/fruits` if we wanted to.

Basically the issue is because PathPrefix uses Lotus::Kernel.Array which calls .uniq! on itself and removes any duplicate items.

I was able to fix the issue by using the standard array for the relative_join + calling chomp("/") on the result of the join to make some tests happy. 

I'm not entirely sold on this solution because it seems to me that even though this fixed the problem entirely as far as I can tell (all tests pass*), Kernel.Array was put there for a reason beyond my understanding at this point. So please let me know what you think!

*While all tests pass on Utils, Router, Lotus and the example app with the initial problem (linked below), I had to amend 2 tests on Router which probably needs review since i'm not very happy with changing tests without knowing exactly what it is that it's testing. 

I've added failing tests and solution to both Utils and Router. Please let me know what you think and if you need me to clarify anything.

Link to the app with the initial routing issue + failing tests:
https://github.com/theocodes/routertest



Thanks!