### PR TITLE
Fix Encoding::UndefinedConversionError in encode method.

### DIFF
--- a/lib/lotus/utils/escape.rb
+++ b/lib/lotus/utils/escape.rb
@@ -529,6 +529,8 @@ module Lotus
       # @api private
       def self.encode(input)
         input.to_s.encode(Encoding::UTF_8)
+      rescue Encoding::UndefinedConversionError
+        input.to_s.force_encoding(Encoding::UTF_8)
       end
 
       # Encode the given UTF-8 char.

--- a/test/escape_test.rb
+++ b/test/escape_test.rb
@@ -100,6 +100,14 @@ describe Lotus::Utils::Escape do
         end
       end
     end
+
+    # 'тест' means test in russian
+    it "escapes 'тест'" do
+      skip "There is no ASCII-8BIT encoding" unless Encoding.name_list.include?('ASCII-8BIT')
+
+      result = mod.html('тест'.force_encoding('ASCII-8BIT'))
+      result.must_equal 'тест'
+    end
   end
 
   describe '.html_attribute' do


### PR DESCRIPTION
I defined following code in controller.
```ruby
module Web::Controllers::Home
  class Index
    # ...
    def call(params)
      @tag = params[:tag]
    end
  end
end
```
Then I received Encoding::UndefinedConversionError in template from method self.encode in Lotus::Utils when tag contain cyrillic symbols. For some reason params[:tag] have ASCII-8BIT encoding.

So, I added quick fix for that issue.