### PR TITLE
Introducing Lotus::Utils::String#rsub

### DIFF
--- a/lib/lotus/utils/string.rb
+++ b/lib/lotus/utils/string.rb
@@ -340,6 +340,40 @@ module Lotus
         end
       end
 
+      # Replace the rightmost match of <tt>pattern</tt> with <tt>replacement</tt>
+      #
+      # If the pattern cannot be matched, it returns the original string.
+      #
+      # This method does NOT mutate the original string.
+      #
+      # @param pattern [Regexp, String] the pattern to find
+      # @param replacement [String, Lotus::Utils::String] the string to replace
+      #
+      # @return [Lotus::Utils::String] the replaced string
+      #
+      # @since x.x.x
+      #
+      # @example
+      #   require 'lotus/utils/string'
+      #
+      #   string = Lotus::Utils::String.new('authors/books/index')
+      #   result = string.rsub(/\//, '#')
+      #
+      #   puts string
+      #     # => #<Lotus::Utils::String:0x007fdb41233ad8 @string="authors/books/index">
+      #
+      #   puts result
+      #     # => #<Lotus::Utils::String:0x007fdb41232ed0 @string="authors/books#index">
+      def rsub(pattern, replacement)
+        if i = rindex(pattern)
+          s    = @string.dup
+          s[i] = replacement
+          self.class.new s
+        else
+          self
+        end
+      end
+
       # Override Ruby's method_missing in order to provide ::String interface
       #
       # @api private

--- a/test/string_test.rb
+++ b/test/string_test.rb
@@ -267,6 +267,42 @@ describe Lotus::Utils::String do
     end
   end
 
+  describe "#rsub" do
+    it 'returns a Lotus::Utils::String instance' do
+      result = Lotus::Utils::String.new('authors/books/index').rsub(//, '')
+      result.must_be_kind_of(Lotus::Utils::String)
+    end
+
+    it "doesn't mutate original string" do
+      string = Lotus::Utils::String.new('authors/books/index')
+      string.rsub(/\//, '#')
+
+      string.must_equal('authors/books/index')
+    end
+
+    it 'replaces rightmost instance (regexp)' do
+      result = Lotus::Utils::String.new('authors/books/index').rsub(/\//, '#')
+      result.must_equal('authors/books#index')
+    end
+
+    it 'replaces rightmost instance (string)' do
+      result = Lotus::Utils::String.new('authors/books/index').rsub('/', '#')
+      result.must_equal('authors/books#index')
+    end
+
+    it 'accepts Lotus::Utils::String as replacement' do
+      replacement = Lotus::Utils::String.new('#')
+      result      = Lotus::Utils::String.new('authors/books/index').rsub(/\//, replacement)
+
+      result.must_equal('authors/books#index')
+    end
+
+    it 'returns the initial string no match' do
+      result = Lotus::Utils::String.new('index').rsub(/\//, '#')
+      result.must_equal('index')
+    end
+  end
+
   describe 'string interface' do
     it 'responds to ::String methods and returns a new Lotus::Utils::String' do
       string = Lotus::Utils::String.new("Lotus\n").chomp


### PR DESCRIPTION
It replaces rightmost occurence of given pattern and replaces with given replacement.

```ruby
require 'lotus/utils/string'

string = Lotus::Utils::String.new('authors/books/index')
string.rsub("/", "#") # => "authors/books#index"
```

This feature supports https://github.com/lotus/router/pull/76

/cc @lotus/core-team 