### PR TITLE
Reduce allocations for String#classify method

### DIFF
--- a/lib/lotus/utils/string.rb
+++ b/lib/lotus/utils/string.rb
@@ -6,6 +6,12 @@ module Lotus
     #
     # @since 0.1.0
     class String
+      # Empty string for #classify
+      #
+      # @since 0.6.0
+      # @api private
+      EMPTY_STRING        = ''.freeze
+
       # Separator between Ruby namespaces
       #
       # @since 0.1.0
@@ -135,14 +141,14 @@ module Lotus
       #   string = Lotus::Utils::String.new 'lotus_utils'
       #   string.classify # => 'LotusUtils'
       def classify
-        words = split(CLASSIFY_WORD_SEPARATOR).map(&:capitalize)
+        words = split(CLASSIFY_WORD_SEPARATOR).map!(&:capitalize)
         delimiters = scan(CLASSIFY_WORD_SEPARATOR)
 
         delimiters.map! do |delimiter|
-          delimiter == CLASSIFY_SEPARATOR ? nil : NAMESPACE_SEPARATOR
+          delimiter == CLASSIFY_SEPARATOR ? EMPTY_STRING : NAMESPACE_SEPARATOR
         end
 
-        self.class.new words.zip(delimiters).compact.join
+        self.class.new words.zip(delimiters).join
       end
 
       # Return a downcased and underscore separated version of the string
@@ -338,6 +344,17 @@ module Lotus
         else
           @string.gsub(pattern, replacement)
         end
+      end
+
+      # Both forms iterate through str, matching the pattern
+      #
+      # @return [String,nil]
+      #
+      # @see http://www.ruby-doc.org/core/String.html#method-i-scan
+      #
+      # @since 0.6.0
+      def scan(pattern, &blk)
+        @string.scan(pattern, &blk)
       end
 
       # Replace the rightmost match of <tt>pattern</tt> with <tt>replacement</tt>


### PR DESCRIPTION
I used stackprof gem and this code:
``` ruby
  100_000.times { Lotus::Utils::String.new('lotus_utils/test').classify }
```

### Before
```
==================================
  Mode: object(1)
  Samples: 3500005 (0.00% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
   3300005  (94.3%)     1600004  (45.7%)     Lotus::Utils::String#classify
    900000  (25.7%)      900000  (25.7%)     Lotus::Utils::String#method_missing
    800001  (22.9%)      800001  (22.9%)     Lotus::Utils::String#split
```

### After
```
==================================
  Mode: object(1)
  Samples: 3000005 (0.00% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
   2800005  (93.3%)     1100004  (36.7%)     Lotus::Utils::String#classify
    900000  (30.0%)      900000  (30.0%)     Lotus::Utils::String#scan
    800001  (26.7%)      800001  (26.7%)     Lotus::Utils::String#split
```

:tada: 