### PR TITLE
Remove pattern support for Lotus::Utils::Class#load!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Ruby core extentions and class utilities for Lotus
 
 ### Changed
 - [Luca Guidi] Removed `Lotus::Utils::Callbacks#add` in favor of `#append`
+- [Luca Guidi] Removed pattern support for `Utils::Class.load!` (eg. `Articles(Controller|::Controller)`)
 
 ## v0.5.2 - 2015-09-30
 ### Added

--- a/lib/lotus/utils/class.rb
+++ b/lib/lotus/utils/class.rb
@@ -1,5 +1,4 @@
 require 'lotus/utils/string'
-require 'lotus/utils/deprecation'
 
 module Lotus
   module Utils
@@ -39,14 +38,7 @@ module Lotus
       #   # with missing constant
       #   Lotus::Utils::Class.load!('Unknown') # => raises NameError
       def self.load!(name, namespace = Object)
-        name = name.to_s
-
-        if name.match(/\|/)
-          Utils::Deprecation.new("Using Lotus::Utils::Class.load! with a pattern is deprecated, please use Lotus::Utils::Class.load_from_pattern!: #{ name }, #{ namespace }")
-          return load_from_pattern!(name, namespace)
-        end
-
-        namespace.const_get(name)
+        namespace.const_get(name.to_s)
       end
 
       # Loads a class from the given pattern name and namespace

--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -35,14 +35,6 @@ describe Lotus::Utils::Class do
     it 'raises an error in case of missing class' do
       -> { Lotus::Utils::Class.load!('Missing') }.must_raise(NameError)
     end
-
-    it 'prints a deprecation warning if used with a pattern' do
-      _, err = capture_io do
-        Lotus::Utils::Class.load!('(Layer|Layer::)Step', App).must_equal(App::Layer::Step)
-      end
-
-      err.must_include "Using Lotus::Utils::Class.load! with a pattern is deprecated, please use Lotus::Utils::Class.load_from_pattern!: (Layer|Layer::)Step, App"
-    end
   end
 
   describe '.load_from_pattern!' do


### PR DESCRIPTION
It was deprecated by `v0.3.1` (a46aecf6bfa620c7d0a578768ad7b7fe5253cef5)